### PR TITLE
API change for Timestamp

### DIFF
--- a/core/src/inherent/timestamp.rs
+++ b/core/src/inherent/timestamp.rs
@@ -16,15 +16,19 @@ use sp_core::sp_std::sync::Arc;
 use sp_inherents::{InherentData, InherentIdentifier};
 use sp_runtime::SaturatedConversion;
 use sp_std::collections::btree_map::BTreeMap;
+use sp_std::sync::atomic::{AtomicU64, Ordering};
 use sp_std::sync::Mutex;
 use sp_std::time::Duration;
 use sp_timestamp::{InherentError, INHERENT_IDENTIFIER};
 
 lazy_static::lazy_static!(
 	pub static ref INSTANCES: Arc<Mutex<BTreeMap<Instance, CurrTimeProvider>>> = Arc::new(Mutex::new(BTreeMap::new()));
+	pub static ref COUNTER: Arc<AtomicU64> = Arc::new(AtomicU64::new());
 );
 
-pub type Instance = u64;
+#[derive(Copy)]
+pub struct Instance(u64);
+
 pub type Ticks = u128;
 
 #[derive(Clone, Debug)]
@@ -36,10 +40,14 @@ pub struct CurrTimeProvider {
 }
 
 impl CurrTimeProvider {
-	/// Creates a new instance and returns the **old** instance of it was existing.
+	/// Overwrites an existing instance. If the instance was not yet existant, returns an error.
 	///
 	/// To get the actual instance please use `CurrTimeProvider::get_instance()`.
-	pub fn new(instance: Instance, delta: Duration, start: Option<Duration>) -> Option<Self> {
+	pub fn force_new(
+		instance: Instance,
+		delta: Duration,
+		start: Option<Duration>,
+	) -> Result<(), ()> {
 		let storage = INSTANCES.clone();
 		let mut locked_instances = storage.lock().expect("Time MUST NOT fail.");
 
@@ -54,7 +62,36 @@ impl CurrTimeProvider {
 			dur
 		};
 
-		let prev = locked_instances.insert(
+		locked_instances
+			.get_mut(&instance)
+			.map(|time| {
+				*time = CurrTimeProvider {
+					instance,
+					start,
+					delta,
+					ticks: 0,
+				};
+			})
+			.ok_or(())
+	}
+
+	pub fn create_instance(delta: Duration, start: Option<Duration>) -> Instance {
+		let instance = Instance(COUNTER.fetch_add(1, Ordering::SeqCst));
+
+		let start = if let Some(start) = start {
+			start
+		} else {
+			let now = std::time::SystemTime::now();
+			let dur = now
+				.duration_since(std::time::SystemTime::UNIX_EPOCH)
+				.expect("Current time is always after unix epoch; qed");
+
+			dur
+		};
+
+		let storage = INSTANCES.clone();
+		let mut locked_instances = storage.lock().expect("Time MUST NOT fail.");
+		locked_instances.insert(
 			instance,
 			CurrTimeProvider {
 				instance,
@@ -64,15 +101,7 @@ impl CurrTimeProvider {
 			},
 		);
 
-		if let Some(ref old_instance) = prev {
-			tracing::event!(
-				tracing::Level::WARN,
-				"Overwriting time-instance. Previous instance was {:?}.",
-				old_instance
-			);
-		}
-
-		prev
+		instance
 	}
 
 	pub fn get_instance(instance: Instance) -> Option<Self> {
@@ -141,8 +170,9 @@ mod test {
 		const DELTA: u64 = 12u64;
 
 		let delta = Duration::from_secs(DELTA);
-		CurrTimeProvider::new(0, delta, Some(Duration::from_secs(START_DATE)));
-		let time = CurrTimeProvider::get_instance(0).expect("Instance is initialized. qed");
+		let instance =
+			CurrTimeProvider::create_instance(delta, Some(Duration::from_secs(START_DATE)));
+		let time = CurrTimeProvider::get_instance(instance).expect("Instance is initialized. qed");
 
 		assert_eq!(
 			time.current_time().as_duration().as_secs() as u64,
@@ -151,7 +181,7 @@ mod test {
 
 		// Progress time by delta
 		time.update_time();
-		let time = CurrTimeProvider::get_instance(0).expect("Instance is initialized. qed");
+		let time = CurrTimeProvider::get_instance(instance).expect("Instance is initialized. qed");
 		assert_eq!(
 			time.current_time().as_duration().as_secs() as u64,
 			START_DATE + delta.as_secs() as u64
@@ -159,7 +189,7 @@ mod test {
 
 		// Progress time by delta
 		time.update_time();
-		let time = CurrTimeProvider::get_instance(0).expect("Instance is initialized. qed");
+		let time = CurrTimeProvider::get_instance(instance).expect("Instance is initialized. qed");
 		assert_eq!(
 			time.current_time().as_duration().as_secs() as u64,
 			START_DATE + 2 * delta.as_secs() as u64
@@ -172,12 +202,16 @@ mod test {
 		const DELTA_B: u64 = 6u64;
 
 		let delta_a = Duration::from_secs(DELTA_A);
-		CurrTimeProvider::new(3, delta_a, Some(Duration::from_secs(START_DATE)));
-		let time_a = CurrTimeProvider::get_instance(3).expect("Instance is initialized. qed");
+		let instance_a =
+			CurrTimeProvider::create_instance(delta_a, Some(Duration::from_secs(START_DATE)));
+		let time_a =
+			CurrTimeProvider::get_instance(instance_a).expect("Instance is initialized. qed");
 
 		let delta_b = Duration::from_secs(DELTA_A);
-		CurrTimeProvider::new(4, delta_b, Some(Duration::from_secs(START_DATE)));
-		let time_b = CurrTimeProvider::get_instance(4).expect("Instance is initialized. qed");
+		let instance_b =
+			CurrTimeProvider::create_instance(delta_b, Some(Duration::from_secs(START_DATE)));
+		let time_b =
+			CurrTimeProvider::get_instance(instance_b).expect("Instance is initialized. qed");
 
 		assert_eq!(
 			time_a.current_time().as_duration().as_secs() as u64,
@@ -190,9 +224,11 @@ mod test {
 
 		// Progress time by delta
 		time_a.update_time();
-		let time_a = CurrTimeProvider::get_instance(3).expect("Instance is initialized. qed");
+		let time_a =
+			CurrTimeProvider::get_instance(instance_a).expect("Instance is initialized. qed");
 		time_b.update_time();
-		let time_b = CurrTimeProvider::get_instance(4).expect("Instance is initialized. qed");
+		let time_b =
+			CurrTimeProvider::get_instance(instance_b).expect("Instance is initialized. qed");
 		assert_eq!(
 			time_a.current_time().as_duration().as_secs() as u64,
 			START_DATE + delta_a.as_secs() as u64
@@ -204,9 +240,11 @@ mod test {
 
 		// Progress time by delta
 		time_a.update_time();
-		let time_a = CurrTimeProvider::get_instance(3).expect("Instance is initialized. qed");
+		let time_a =
+			CurrTimeProvider::get_instance(instance_a).expect("Instance is initialized. qed");
 		time_b.update_time();
-		let time_b = CurrTimeProvider::get_instance(4).expect("Instance is initialized. qed");
+		let time_b =
+			CurrTimeProvider::get_instance(instance_b).expect("Instance is initialized. qed");
 		assert_eq!(
 			time_a.current_time().as_duration().as_secs() as u64,
 			START_DATE + 2 * delta_a.as_secs() as u64
@@ -216,8 +254,10 @@ mod test {
 			START_DATE + 2 * delta_b.as_secs() as u64
 		);
 
-		let time_a_2 = CurrTimeProvider::get_instance(3).expect("Instance is available. qed");
-		let time_b_2 = CurrTimeProvider::get_instance(4).expect("Instance is available. qed");
+		let time_a_2 =
+			CurrTimeProvider::get_instance(instance_a).expect("Instance is available. qed");
+		let time_b_2 =
+			CurrTimeProvider::get_instance(instance_b).expect("Instance is available. qed");
 
 		assert_eq!(time_a.current_time(), time_a_2.current_time());
 		assert_eq!(time_b.current_time(), time_b_2.current_time());

--- a/core/src/provider/externalities_provider.rs
+++ b/core/src/provider/externalities_provider.rs
@@ -53,7 +53,7 @@ where
 		)
 	}
 	/*
-	/// Create a new instance of `TestExternalities` with storage.
+	/// Create a new instance_id of `TestExternalities` with storage.
 	pub fn new(storage: Storage) -> Self {
 		Self::new_with_code(&[], storage)
 	}
@@ -63,7 +63,7 @@ where
 		Self::new_with_code(&[], Storage::default())
 	}
 
-	/// Create a new instance of `TestExternalities` with code and storage.
+	/// Create a new instance_id of `TestExternalities` with code and storage.
 	pub fn new_with_code(code: &[u8], mut storage: Storage) -> Self {
 		let mut overlay = OverlayedChanges::default();
 		let changes_trie_config = storage
@@ -113,7 +113,7 @@ where
 		self.backend.insert(vec![(None, vec![(k, Some(v))])]);
 	}
 
-	/// Registers the given extension for this instance.
+	/// Registers the given extension for this instance_id.
 	pub fn register_extension<E: Any + Extension>(&mut self, ext: E) {
 		self.extensions.register(ext);
 	}

--- a/core/src/tests/parachain.rs
+++ b/core/src/tests/parachain.rs
@@ -162,7 +162,8 @@ where
 	let client = Arc::new(client);
 	let clone_client = client.clone();
 	// Init timestamp instance
-	FudgeInherentTimestamp::new(0, sp_std::time::Duration::from_secs(6), None);
+	let instance =
+		FudgeInherentTimestamp::create_instance(sp_std::time::Duration::from_secs(6), None);
 
 	let cidp = Box::new(
 		|clone_client: Arc<
@@ -180,7 +181,7 @@ where
 						&*client, parent,
 					)?;
 
-					let timestamp = FudgeInherentTimestamp::get_instance(0)
+					let timestamp = FudgeInherentTimestamp::get_instance(instance)
 						.expect("Instance is initialized. qed");
 
 					let slot =
@@ -223,14 +224,15 @@ async fn parachain_creates_correct_inherents() {
 	let para_id = Id::from(2001u32);
 	let inherent_builder = relay_builder.inherent_builder(para_id.clone());
 	// Init timestamp instance
-	FudgeInherentTimestamp::new(1, sp_std::time::Duration::from_secs(12), None);
+	let instance_para =
+		FudgeInherentTimestamp::create_instance(sp_std::time::Duration::from_secs(12), None);
 
 	let cidp = Box::new(|_| {
 		move |_parent: H256, ()| {
 			let inherent_builder_clone = inherent_builder.clone();
 			async move {
-				let timestamp =
-					FudgeInherentTimestamp::get_instance(1).expect("Instance is initialized. qed");
+				let timestamp = FudgeInherentTimestamp::get_instance(instance_para)
+					.expect("Instance is initialized. qed");
 
 				let slot =
 					sp_consensus_babe::inherents::InherentDataProvider::from_timestamp_and_slot_duration(

--- a/core/src/tests/parachain.rs
+++ b/core/src/tests/parachain.rs
@@ -161,8 +161,8 @@ where
 	);
 	let client = Arc::new(client);
 	let clone_client = client.clone();
-	// Init timestamp instance
-	let instance =
+	// Init timestamp instance_id
+	let instance_id =
 		FudgeInherentTimestamp::create_instance(sp_std::time::Duration::from_secs(6), None);
 
 	let cidp = Box::new(
@@ -181,7 +181,7 @@ where
 						&*client, parent,
 					)?;
 
-					let timestamp = FudgeInherentTimestamp::get_instance(instance)
+					let timestamp = FudgeInherentTimestamp::get_instance(instance_id)
 						.expect("Instance is initialized. qed");
 
 					let slot =
@@ -223,15 +223,15 @@ async fn parachain_creates_correct_inherents() {
 		generate_default_setup_relay_chain::<RRuntime>(&manager, Storage::default());
 	let para_id = Id::from(2001u32);
 	let inherent_builder = relay_builder.inherent_builder(para_id.clone());
-	// Init timestamp instance
-	let instance_para =
+	// Init timestamp instance_id
+	let instance_id_para =
 		FudgeInherentTimestamp::create_instance(sp_std::time::Duration::from_secs(12), None);
 
-	let cidp = Box::new(|_| {
+	let cidp = Box::new(move |_| {
 		move |_parent: H256, ()| {
 			let inherent_builder_clone = inherent_builder.clone();
 			async move {
-				let timestamp = FudgeInherentTimestamp::get_instance(instance_para)
+				let timestamp = FudgeInherentTimestamp::get_instance(instance_id_para)
 					.expect("Instance is initialized. qed");
 
 				let slot =

--- a/core/src/tests/relay_chain.rs
+++ b/core/src/tests/relay_chain.rs
@@ -86,7 +86,8 @@ async fn onboarding_parachain_works() {
 
 	let manager = TaskManager::new(Handle::current(), None).unwrap();
 	// Init timestamp instance
-	FudgeInherentTimestamp::new(0, sp_std::time::Duration::from_secs(6), None);
+	let instance =
+		FudgeInherentTimestamp::create_instance(sp_std::time::Duration::from_secs(6), None);
 
 	let cidp = Box::new(
 		|clone_client: Arc<
@@ -104,7 +105,7 @@ async fn onboarding_parachain_works() {
 						&*client, parent,
 					)?;
 
-					let timestamp = FudgeInherentTimestamp::get_instance(0)
+					let timestamp = FudgeInherentTimestamp::get_instance(instance)
 						.expect("Instance is initialized. qed");
 
 					let slot =

--- a/core/src/tests/relay_chain.rs
+++ b/core/src/tests/relay_chain.rs
@@ -85,12 +85,12 @@ async fn onboarding_parachain_works() {
 	super::utils::init_logs();
 
 	let manager = TaskManager::new(Handle::current(), None).unwrap();
-	// Init timestamp instance
-	let instance =
+	// Init timestamp instance_id
+	let instance_id =
 		FudgeInherentTimestamp::create_instance(sp_std::time::Duration::from_secs(6), None);
 
 	let cidp = Box::new(
-		|clone_client: Arc<
+		move |clone_client: Arc<
 			TFullClient<TestBlock, TestRtApi, TestExec<sp_io::SubstrateHostFunctions>>,
 		>| {
 			move |parent: H256, ()| {
@@ -105,7 +105,7 @@ async fn onboarding_parachain_works() {
 						&*client, parent,
 					)?;
 
-					let timestamp = FudgeInherentTimestamp::get_instance(instance)
+					let timestamp = FudgeInherentTimestamp::get_instance(instance_id)
 						.expect("Instance is initialized. qed");
 
 					let slot =

--- a/core/src/tests/stand_alone.rs
+++ b/core/src/tests/stand_alone.rs
@@ -88,7 +88,8 @@ async fn mutating_genesis_works() {
 	.build_storage()
 	.unwrap();
 	// Init timestamp instance
-	FudgeInherentTimestamp::new(0, sp_std::time::Duration::from_secs(6), None);
+	let instance =
+		FudgeInherentTimestamp::create_instance(sp_std::time::Duration::from_secs(6), None);
 
 	let cidp = Box::new(
 		|clone_client: Arc<
@@ -106,7 +107,7 @@ async fn mutating_genesis_works() {
 						&*client, parent,
 					)?;
 
-					let timestamp = FudgeInherentTimestamp::get_instance(0)
+					let timestamp = FudgeInherentTimestamp::get_instance(instance)
 						.expect("Instance is initialized. qed");
 
 					let slot =
@@ -205,7 +206,8 @@ async fn build_relay_block_works() {
 
 	let manager = TaskManager::new(Handle::current(), None).unwrap();
 	// Init timestamp instance
-	FudgeInherentTimestamp::new(0, sp_std::time::Duration::from_secs(6), None);
+	let instance =
+		FudgeInherentTimestamp::create_instance(sp_std::time::Duration::from_secs(6), None);
 
 	let cidp = Box::new(
 		|clone_client: Arc<
@@ -223,7 +225,7 @@ async fn build_relay_block_works() {
 						&*client, parent,
 					)?;
 
-					let timestamp = FudgeInherentTimestamp::get_instance(0)
+					let timestamp = FudgeInherentTimestamp::get_instance(instance)
 						.expect("Instance is initialized. qed");
 					let slot =
 						sp_consensus_babe::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
@@ -280,7 +282,8 @@ async fn build_relay_block_works_and_mut_is_build_upon() {
 
 	let manager = TaskManager::new(Handle::current(), None).unwrap();
 	// Init timestamp instance
-	FudgeInherentTimestamp::new(0, sp_std::time::Duration::from_secs(6), None);
+	let instance =
+		FudgeInherentTimestamp::create_instance(sp_std::time::Duration::from_secs(6), None);
 
 	let cidp = Box::new(
 		|clone_client: Arc<
@@ -298,7 +301,7 @@ async fn build_relay_block_works_and_mut_is_build_upon() {
 						&*client, parent,
 					)?;
 
-					let timestamp = FudgeInherentTimestamp::get_instance(0)
+					let timestamp = FudgeInherentTimestamp::get_instance(instance)
 						.expect("Instance is initialized. qed");
 					let slot =
 						sp_consensus_babe::inherents::InherentDataProvider::from_timestamp_and_slot_duration(

--- a/core/src/tests/stand_alone.rs
+++ b/core/src/tests/stand_alone.rs
@@ -87,12 +87,12 @@ async fn mutating_genesis_works() {
 	}
 	.build_storage()
 	.unwrap();
-	// Init timestamp instance
-	let instance =
+	// Init timestamp instance_id
+	let instance_id =
 		FudgeInherentTimestamp::create_instance(sp_std::time::Duration::from_secs(6), None);
 
 	let cidp = Box::new(
-		|clone_client: Arc<
+		move |clone_client: Arc<
 			TFullClient<TestBlock, TestRtApi, TestExec<sp_io::SubstrateHostFunctions>>,
 		>| {
 			move |parent: H256, ()| {
@@ -107,7 +107,7 @@ async fn mutating_genesis_works() {
 						&*client, parent,
 					)?;
 
-					let timestamp = FudgeInherentTimestamp::get_instance(instance)
+					let timestamp = FudgeInherentTimestamp::get_instance(instance_id)
 						.expect("Instance is initialized. qed");
 
 					let slot =
@@ -205,12 +205,12 @@ async fn build_relay_block_works() {
 	super::utils::init_logs();
 
 	let manager = TaskManager::new(Handle::current(), None).unwrap();
-	// Init timestamp instance
-	let instance =
+	// Init timestamp instance_id
+	let instance_id =
 		FudgeInherentTimestamp::create_instance(sp_std::time::Duration::from_secs(6), None);
 
 	let cidp = Box::new(
-		|clone_client: Arc<
+		move |clone_client: Arc<
 			TFullClient<TestBlock, TestRtApi, TestExec<sp_io::SubstrateHostFunctions>>,
 		>| {
 			move |parent: H256, ()| {
@@ -225,7 +225,7 @@ async fn build_relay_block_works() {
 						&*client, parent,
 					)?;
 
-					let timestamp = FudgeInherentTimestamp::get_instance(instance)
+					let timestamp = FudgeInherentTimestamp::get_instance(instance_id)
 						.expect("Instance is initialized. qed");
 					let slot =
 						sp_consensus_babe::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
@@ -281,12 +281,12 @@ async fn build_relay_block_works_and_mut_is_build_upon() {
 	super::utils::init_logs();
 
 	let manager = TaskManager::new(Handle::current(), None).unwrap();
-	// Init timestamp instance
-	let instance =
+	// Init timestamp instance_id
+	let instance_id =
 		FudgeInherentTimestamp::create_instance(sp_std::time::Duration::from_secs(6), None);
 
 	let cidp = Box::new(
-		|clone_client: Arc<
+		move |clone_client: Arc<
 			TFullClient<TestBlock, TestRtApi, TestExec<sp_io::SubstrateHostFunctions>>,
 		>| {
 			move |parent: H256, ()| {
@@ -301,7 +301,7 @@ async fn build_relay_block_works_and_mut_is_build_upon() {
 						&*client, parent,
 					)?;
 
-					let timestamp = FudgeInherentTimestamp::get_instance(instance)
+					let timestamp = FudgeInherentTimestamp::get_instance(instance_id)
 						.expect("Instance is initialized. qed");
 					let slot =
 						sp_consensus_babe::inherents::InherentDataProvider::from_timestamp_and_slot_duration(


### PR DESCRIPTION
Do force users to let the timestamp generate instances and return ids. 
Users can `force_new` a timestamp by using the provided id. 