### PR TITLE
Feature/minor improvments

### DIFF
--- a/core/src/builder/parachain.rs
+++ b/core/src/builder/parachain.rs
@@ -209,7 +209,7 @@ where
 			inherents,
 			digest,
 			Duration::from_secs(60),
-			6_000_000,
+			usize::MAX,
 		);
 		self.next = Some((block, proof));
 

--- a/core/src/builder/parachain.rs
+++ b/core/src/builder/parachain.rs
@@ -13,7 +13,8 @@
 use codec::Encode;
 use polkadot_parachain::primitives::{BlockData, HeadData, Id, ValidationCode};
 use sc_client_api::{
-	AuxStore, Backend as BackendT, BlockBackend, BlockOf, HeaderBackend, UsageProvider,
+	AuxStore, Backend as BackendT, BlockBackend, BlockOf, HeaderBackend, TransactionFor,
+	UsageProvider,
 };
 use sc_client_db::Backend;
 use sc_consensus::{BlockImport, BlockImportParams, ForkChoiceStrategy};
@@ -110,6 +111,7 @@ where
 		+ BlockImport<Block>
 		+ CallApiAt<Block>
 		+ sc_block_builder::BlockBuilderProvider<B, Block, C>,
+	for<'r> &'r C: BlockImport<Block, Transaction = TransactionFor<B, Block>>,
 	A: TransactionPool<Block = Block, Hash = Block::Hash> + MaintainedTransactionPool + 'static,
 {
 	pub fn new<I, F>(initiator: I, setup: F) -> Self

--- a/core/src/builder/relay_chain.rs
+++ b/core/src/builder/relay_chain.rs
@@ -425,7 +425,7 @@ where
 			inherents,
 			digest,
 			Duration::from_secs(60),
-			6_000_000,
+			usize::MAX,
 		);
 		self.next = Some((block.clone(), proof));
 

--- a/core/src/builder/relay_chain.rs
+++ b/core/src/builder/relay_chain.rs
@@ -18,7 +18,7 @@ use polkadot_primitives::{runtime_api::ParachainHost, v2::OccupiedCoreAssumption
 use polkadot_runtime_parachains::{paras, ParaLifecycle};
 use sc_client_api::{
 	AuxStore, Backend as BackendT, BlockBackend, BlockOf, BlockchainEvents, HeaderBackend,
-	UsageProvider,
+	TransactionFor, UsageProvider,
 };
 use sc_client_db::Backend;
 use sc_consensus::{BlockImport, BlockImportParams, ForkChoiceStrategy};
@@ -269,6 +269,7 @@ where
 		+ BlockImport<Block>
 		+ CallApiAt<Block>
 		+ sc_block_builder::BlockBuilderProvider<B, Block, C>,
+	for<'r> &'r C: BlockImport<Block, Transaction = TransactionFor<B, Block>>,
 	A: TransactionPool<Block = Block, Hash = Block::Hash> + MaintainedTransactionPool + 'static,
 {
 	pub fn new<I, F>(initiator: I, setup: F) -> Self

--- a/core/src/builder/stand_alone.rs
+++ b/core/src/builder/stand_alone.rs
@@ -10,7 +10,8 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 use sc_client_api::{
-	AuxStore, Backend as BackendT, BlockBackend, BlockOf, HeaderBackend, UsageProvider,
+	AuxStore, Backend as BackendT, BlockBackend, BlockOf, HeaderBackend, TransactionFor,
+	UsageProvider,
 };
 use sc_client_db::Backend;
 use sc_consensus::{BlockImport, BlockImportParams, ForkChoiceStrategy};
@@ -96,6 +97,7 @@ where
 		+ BlockImport<Block>
 		+ CallApiAt<Block>
 		+ sc_block_builder::BlockBuilderProvider<B, Block, C>,
+	for<'r> &'r C: BlockImport<Block, Transaction = TransactionFor<B, Block>>,
 	A: TransactionPool<Block = Block, Hash = Block::Hash> + MaintainedTransactionPool + 'static,
 {
 	pub fn new<I, F>(initiator: I, setup: F) -> Self

--- a/core/src/builder/stand_alone.rs
+++ b/core/src/builder/stand_alone.rs
@@ -195,7 +195,7 @@ where
 			inherents,
 			digest,
 			Duration::from_secs(60),
-			6_000_000,
+			usize::MAX,
 		);
 		self.next = Some((block.clone(), proof));
 

--- a/core/src/provider/initiator.rs
+++ b/core/src/provider/initiator.rs
@@ -20,7 +20,7 @@ use polkadot_cli::service::HeaderBackend;
 use sc_block_builder::{BlockBuilderApi, BlockBuilderProvider};
 use sc_client_api::{
 	execution_extensions::ExecutionStrategies, AuxStore, Backend, BlockBackend, BlockOf,
-	UsageProvider,
+	TransactionFor, UsageProvider,
 };
 use sc_consensus::BlockImport;
 use sc_executor::{RuntimeVersionOf, WasmExecutionMethod, WasmExecutor};
@@ -139,6 +139,7 @@ where
 		+ BlockImport<Block>
 		+ CallApiAt<Block>
 		+ BlockBuilderProvider<CP::Backend, Block, CP::Client>,
+	for<'r> &'r CP::Client: BlockImport<Block, Transaction = TransactionFor<CP::Backend, Block>>,
 {
 	/// Creates a new `Init` instance with some sane defaults:
 	///
@@ -233,6 +234,7 @@ where
 		+ BlockImport<Block>
 		+ CallApiAt<Block>
 		+ BlockBuilderProvider<CP::Backend, Block, CP::Client>,
+	for<'r> &'r CP::Client: BlockImport<Block, Transaction = TransactionFor<CP::Backend, Block>>,
 {
 	type Api = CP::Api;
 	type Backend = CP::Backend;

--- a/core/src/provider/mod.rs
+++ b/core/src/provider/mod.rs
@@ -15,7 +15,7 @@ use std::{error::Error, marker::PhantomData, sync::Arc};
 use sc_block_builder::{BlockBuilderApi, BlockBuilderProvider};
 use sc_client_api::{
 	execution_extensions::ExecutionStrategies, AuxStore, Backend as BackendT, Backend,
-	BlockBackend, BlockOf, HeaderBackend, UsageProvider,
+	BlockBackend, BlockOf, HeaderBackend, TransactionFor, UsageProvider,
 };
 use sc_consensus::BlockImport;
 #[cfg(feature = "runtime-benchmarks")]
@@ -38,7 +38,11 @@ pub mod externalities;
 pub mod initiator;
 pub mod state;
 
-pub trait Initiator<Block: BlockT> {
+pub trait Initiator<Block: BlockT>
+where
+	for<'r> &'r Self::Client:
+		BlockImport<Block, Transaction = TransactionFor<Self::Backend, Block>>,
+{
 	type Api: BlockBuilder<Block>
 		+ ApiExt<Block, StateBackend = <Self::Backend as BackendT<Block>>::State>
 		+ BlockBuilderApi<Block>

--- a/fudge/src/lib.rs
+++ b/fudge/src/lib.rs
@@ -10,22 +10,20 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
+//! FUDGE - FUlly Decoupled Generic Environment for Substrate-based Chains
+//!
+//! Generally only this dependency is needed in order to use FUDGE.
+//! Developers who want to use the more raw apis and types are
+//! referred to the fudge-core repository.
+
 pub use fudge_companion::companion;
-use fudge_core::provider::TWasmExecutor;
 pub use fudge_core::{
 	digest, inherent,
 	provider::{
-		backend::{DiskDatabaseType, DiskDb, MemDb},
-		initiator::{FromConfiguration, Init, PoolConfig},
-		state::StateProvider,
-		BackendProvider, ClientProvider, DefaultClient, Initiator,
+		backend, initiator, state, BackendProvider, ClientProvider, DefaultClient, Initiator,
+		TWasmExecutor,
 	},
 };
-///! FUDGE - FUlly Decoupled Generic Environment for Substrate-based Chains
-///!
-///! Generally only this dependency is needed in order to use FUDGE.
-///! Developers who want to use the more raw apis and types are
-///! referred to the fudge-core repository.
 use sc_service::{TFullBackend, TFullClient};
 
 pub type ParachainBuilder<Block, RtApi, CIDP, DP> = fudge_core::ParachainBuilder<

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -10,12 +10,14 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
+#[allow(unused)]
 use fudge::{
 	digest::DigestCreator,
 	inherent::{
 		CreateInherentDataProviders, FudgeDummyInherentRelayParachain, FudgeInherentParaParachain,
 		FudgeInherentTimestamp,
 	},
+	provider::{default, default_with, FromConfiguration},
 	ParachainBuilder, RelaychainBuilder,
 };
 use fudge_test_runtime::{Block as PBlock, RuntimeApi as PRtApi};

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -12,12 +12,14 @@
 
 #[allow(unused)]
 use fudge::{
+	backend::{DiskDatabaseType, DiskDb, MemDb},
 	digest::DigestCreator,
 	inherent::{
 		CreateInherentDataProviders, FudgeDummyInherentRelayParachain, FudgeInherentParaParachain,
 		FudgeInherentTimestamp,
 	},
-	provider::{default, default_with, FromConfiguration},
+	initiator::{default, default_with, FromConfiguration, Init, PoolConfig},
+	state::StateProvider,
 	ParachainBuilder, RelaychainBuilder,
 };
 use fudge_test_runtime::{Block as PBlock, RuntimeApi as PRtApi};


### PR DESCRIPTION
* Removes unsafe aliasing of `Arc<C>` to `&mut C`
* Correctly re-exports stuff of core in fudge crate