### PR TITLE
Feature flags on fudge

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -56,6 +56,7 @@ sc-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = 
 node-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 
 # Substrate frame dependencies
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", optional = true }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }

--- a/core/src/provider/mod.rs
+++ b/core/src/provider/mod.rs
@@ -18,8 +18,6 @@ use sc_client_api::{
 	BlockBackend, BlockOf, HeaderBackend, TransactionFor, UsageProvider,
 };
 use sc_consensus::BlockImport;
-#[cfg(feature = "runtime-benchmarks")]
-use sc_executor::sp_wasm_interface::HostFunctions;
 use sc_executor::{RuntimeVersionOf, WasmExecutor};
 use sc_service::{ClientConfig, LocalCallExecutor, TFullBackend, TFullClient, TaskManager};
 use sc_transaction_pool_api::{MaintainedTransactionPool, TransactionPool};

--- a/core/src/provider/mod.rs
+++ b/core/src/provider/mod.rs
@@ -133,9 +133,11 @@ pub type TWasmExecutor = WasmExecutor<sp_io::SubstrateHostFunctions>;
 
 /// Host functions that include benchmarking specific functionalities
 #[cfg(feature = "runtime-benchmarks")]
-pub type TWasmExecutor = sc_executor::sp_wasm_interface::ExtendedHostFunctions<
-	sp_io::SubstrateHostFunctions,
-	frame_benchmarking::benchmarking::HostFunctions,
+pub type TWasmExecutor = WasmExecutor<
+	sc_executor::sp_wasm_interface::ExtendedHostFunctions<
+		sp_io::SubstrateHostFunctions,
+		frame_benchmarking::benchmarking::HostFunctions,
+	>,
 >;
 
 impl<Block, RtApi, Exec> ClientProvider<Block> for DefaultClient<Block, RtApi, Exec>

--- a/core/src/provider/mod.rs
+++ b/core/src/provider/mod.rs
@@ -127,11 +127,12 @@ impl<Block, RtApi, Exec> DefaultClient<Block, RtApi, Exec> {
 	}
 }
 
-#[cfg(not(feature = "runtime-benchmarks"))]
 /// HostFunctions that do not include benchmarking specific host functions
+#[cfg(not(feature = "runtime-benchmarks"))]
 pub type TWasmExecutor = WasmExecutor<sp_io::SubstrateHostFunctions>;
-#[cfg(feature = "runtime-benchmarks")]
+
 /// Host functions that include benchmarking specific functionalities
+#[cfg(feature = "runtime-benchmarks")]
 pub type TWasmExecutor = sc_executor::sp_wasm_interface::ExtendedHostFunctions<
 	sp_io::SubstrateHostFunctions,
 	frame_benchmarking::benchmarking::HostFunctions,

--- a/fudge/Cargo.toml
+++ b/fudge/Cargo.toml
@@ -13,3 +13,6 @@ polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = 
 sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
+
+[features]
+runtime-benchmarks = ["fudge-core/runtime-benchmarks"]


### PR DESCRIPTION
Enable the propagation of the `runtime-benchmarks` feature flag from `fudge` to `fudge-core` repository.